### PR TITLE
Improve setup and cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ set_package_properties(Boost PROPERTIES TYPE REQUIRED
 
 
 find_package(pybind11)
-if (!{PYBIND11_FOUND})
+if (!{pybind11_FOUND})
   add_subdirectory(external/pybind11)
 endif()
 find_package(pybind11 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,13 +46,10 @@ set_package_properties(Eigen3 PROPERTIES TYPE REQUIRED
 
 
 find_package(CGAL COMPONENTS Core)
-message(STATUS "CGAL FOUND ${CGAL_FOUND}")
 if (!${CGAL_FOUND})
-set(CGAL_DIR external/cgal)
+  set(CGAL_DIR external/cgal)
   find_package(CGAL REQUIRED COMPONENTS Core)
 endif()
-message(STATUS "CGAL FOUND after external search ${CGAL_FOUND}")
-
 include(${CGAL_USE_FILE})
 
 set_package_properties(CGAL PROPERTIES TYPE REQUIRED
@@ -71,7 +68,12 @@ set_package_properties(Boost PROPERTIES TYPE REQUIRED
   DESCRIPTION "Boost C++ libraries"
   URL "http://www.boost.org")
 
-add_subdirectory(external/pybind11)
+
+find_package(pybind11)
+if (!{PYBIND11_FOUND})
+  add_subdirectory(external/pybind11)
+endif()
+find_package(pybind11 REQUIRED)
 
 set( CMAKE_CXX_FLAGS "-fPIC -std=gnu++1z -frounding-math -lgmpxx -lgmp -Wall -I${Boost_INCLUDE_DIRS}")  
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,15 @@ set_package_properties(Eigen3 PROPERTIES TYPE REQUIRED
   DESCRIPTION "Lightweight C++ template library for linear algebra"
   URL "http://eigen.tuxfamily.org")
 
+
+find_package(CGAL COMPONENTS Core)
+message(STATUS "CGAL FOUND ${CGAL_FOUND}")
+if (!${CGAL_FOUND})
 set(CGAL_DIR external/cgal)
-find_package(CGAL REQUIRED COMPONENTS Core)
+  find_package(CGAL REQUIRED COMPONENTS Core)
+endif()
+message(STATUS "CGAL FOUND after external search ${CGAL_FOUND}")
+
 include(${CGAL_USE_FILE})
 
 set_package_properties(CGAL PROPERTIES TYPE REQUIRED
@@ -66,7 +73,7 @@ set_package_properties(Boost PROPERTIES TYPE REQUIRED
 
 add_subdirectory(external/pybind11)
 
-set( CMAKE_CXX_FLAGS "-fPIC -std=gnu++1z -frounding-math -lgmpxx -lgmp -Wall -I${Boost_INCLUDE_DIRS}") 
+set( CMAKE_CXX_FLAGS "-fPIC -std=gnu++1z -frounding-math -lgmpxx -lgmp -Wall -I${Boost_INCLUDE_DIRS}")  
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ class CMakeBuild(build_ext):
             env.get("CXXFLAGS", "-g"),
             self.distribution.get_version()
         )
-        # default to 3 build threads
+        # default to 1 build thread
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in env:
             env["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ class CMakeBuild(build_ext):
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in env:
             env["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
 
+        env["CMAKE_VERBOSE"] = "1"
+
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ class CMakeBuild(build_ext):
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in env:
             env["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
 
-        env["CMAKE_VERBOSE"] = "1"
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,14 @@ class CMakeBuild(build_ext):
             env.get("CXXFLAGS", "-g"),
             self.distribution.get_version()
         )
+        # default to 3 build threads
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in env:
+            env["CMAKE_BUILD_PARALLEL_LEVEL"] = "3"
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(["cmake", "--build",".","-j"] + build_args, cwd=self.build_temp)
+        subprocess.check_call(["cmake", "--build","."] + build_args, cwd=self.build_temp)
 
      
 setup(

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class CMakeBuild(build_ext):
         )
         # default to 3 build threads
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in env:
-            env["CMAKE_BUILD_PARALLEL_LEVEL"] = "3"
+            env["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)


### PR DESCRIPTION
Set serial build as default (can be overridden by adding `export CMAKE_BUILD_PARALLEL_LEVEL=N` where `N` is the number of processes to use.

Alleviate the need for the git submodules if CGAL and pybind11 is already present on system