### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,6 +23,5 @@ jobs:
       run:
         python3 -m pip install -v .
 
-    steps:
     - name: Test import
     - run: python3 -c "import SVMTK"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -24,4 +24,4 @@ jobs:
         python3 -m pip install -v .
 
     - name: Test import
-    - run: python3 -c "import SVMTK"
+      run: python3 -c "import SVMTK"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -25,9 +25,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install -y libeigen3-dev libmpfr-dev libboost-dev
 
-    - name: Install Eigen3 (macos)
+    - name: Install Eigen3, boost (macos)
       if: matrix.os == 'macOS-latest'
-      run: brew install eigen
+      run: brew install eigen boost
 
     
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,28 @@
+name: Test building SVMTK
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        python-version: [3.8, 3.9, 3.10]
+    name: Python ${{ matrix.python-version }} example
+
+    steps:
+    - name: Install SVMTK
+    - uses: actions/checkout@3
+      with: 
+          submodules: true
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version}} 
+      run:
+        python3 -m pip install -v .
+
+    steps:
+    - name: Test import
+    - run: python3 -c "import SVMTK"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,7 +23,7 @@ jobs:
     
     - name: Install Eigen3 (ubuntu)
       if: ${{matrix.os}} == ubuntu-latest
-      run: apt-get install -y libeigen3-dev
+      run: sudo apt-get install -y libeigen3-dev
 
     - name: Install Eigen3 (macos)
       if: ${{matrix.os}} == macOS-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,7 +13,7 @@ jobs:
     name: Python ${{ matrix.python-version }} example
 
     steps:
-    - uses: actions/checkout@3
+    - uses: actions/checkout@v3
       with: 
           submodules: true
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,11 +22,11 @@ jobs:
         python-version: ${{ matrix.python-version }} 
     
     - name: Install Eigen3 (ubuntu)
-      if: matrix.os == "ubuntu-latest"
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install -y libeigen3-dev
 
     - name: Install Eigen3 (macos)
-      if: matrix.os == "macOS-latest"
+      if: matrix.os == 'macOS-latest'
       run: brew install eigen
 
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,7 +23,7 @@ jobs:
     
     - name: Install Eigen3 and mpfr (ubuntu)
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install -y libeigen3-dev mpfr
+      run: sudo apt-get install -y libeigen3-dev libmpfr-dev
 
     - name: Install Eigen3 (macos)
       if: matrix.os == 'macOS-latest'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,14 +21,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }} 
     
-    - name: Install Eigen3 (ubuntu)
+    - name: Install Eigen3 and mpfr (ubuntu)
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install -y libeigen3-dev
+      run: sudo apt-get install -y libeigen3-dev mpfr
 
     - name: Install Eigen3 (macos)
       if: matrix.os == 'macOS-latest'
       run: brew install eigen
 
+    
 
     - name: Install SVMTK
       run:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,6 +21,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version}} 
     
+    - name: Install Eigen3 (ubuntu)
+      if: ${{matrix.os}} == ubuntu-latest
+      run: apt-get install -y libeigen3-dev
+
+    - name: Install Eigen3 (macos)
+      if: ${{matrix.os}} == macOS-latest
+      run: brew install eigen
+
+
     - name: Install SVMTK
       run:
         python3 -m pip install -v .

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }} 
     
-    - name: Install Eigen3 and mpfr (ubuntu)
+    - name: Install Eigen3, mpfr, boost (ubuntu)
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install -y libeigen3-dev libmpfr-dev
+      run: sudo apt-get install -y libeigen3-dev libmpfr-dev libboost-dev
 
     - name: Install Eigen3 (macos)
       if: matrix.os == 'macOS-latest'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
     name: Python ${{ matrix.python-version }} example
 
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,13 +13,15 @@ jobs:
     name: Python ${{ matrix.python-version }} example
 
     steps:
-    - name: Install SVMTK
     - uses: actions/checkout@3
       with: 
           submodules: true
+
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version}} 
+    
+    - name: Install SVMTK
       run:
         python3 -m pip install -v .
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,14 +19,14 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version}} 
+        python-version: ${{ matrix.python-version }} 
     
     - name: Install Eigen3 (ubuntu)
-      if: ${{matrix.os}} == ubuntu-latest
+      if: matrix.os == "ubuntu-latest"
       run: sudo apt-get install -y libeigen3-dev
 
     - name: Install Eigen3 (macos)
-      if: ${{matrix.os}} == macOS-latest
+      if: matrix.os == "macOS-latest"
       run: brew install eigen
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,9 @@ set_package_properties(Eigen3 PROPERTIES TYPE REQUIRED
   URL "http://eigen.tuxfamily.org")
 
 
-find_package(CGAL COMPONENTS Core)
-if (!${CGAL_FOUND})
-  set(CGAL_DIR external/cgal)
-  find_package(CGAL REQUIRED COMPONENTS Core)
-endif()
+
+set(CGAL_DIR external/cgal)
+find_package(CGAL REQUIRED COMPONENTS Core)
 include(${CGAL_USE_FILE})
 
 set_package_properties(CGAL PROPERTIES TYPE REQUIRED
@@ -69,12 +67,7 @@ set_package_properties(Boost PROPERTIES TYPE REQUIRED
   URL "http://www.boost.org")
 
 
-find_package(pybind11)
-if (!{pybind11_FOUND})
-  add_subdirectory(external/pybind11)
-endif()
-find_package(pybind11 REQUIRED)
-
+add_subdirectory(external/pybind11)
 set( CMAKE_CXX_FLAGS "-fPIC -std=gnu++1z -frounding-math -lgmpxx -lgmp -Wall -I${Boost_INCLUDE_DIRS}")  
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
I added some issues with building without having cgal and pybind11 already installed in #7. This reverts that attempt for now.
I've added an issue (#10) to remind us that we should improve this. 

This PR also adds testing building SVMTK on mac (12) and ubuntu (22.04) with python (3.8, 3.9, 3.10).