### PR TITLE
Various packaging fixes

### DIFF
--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -45,5 +45,7 @@ jobs:
       - name: Upload to Anaconda
         env:
           BINSTAR_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run:
-          anaconda -t ${BINSTAR_TOKEN} upload ${CONDA_PREFIX}/conda-bld/linux-64/*.tar.bz2
+        run: |
+          if [[ ! -z "${BINSTAR_TOKEN}" ]]; then
+            anaconda -t ${BINSTAR_TOKEN} upload ${CONDA_PREFIX}/conda-bld/linux-64/*.tar.bz2
+          fi

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -36,6 +36,8 @@ jobs:
     - name: Install SVMTK
       run:
         python3 -m pip install -v .[test]
+      env:
+        CMAKE_BUILD_TESTING: "ON"
 
     - name: Run Tests
       run: pytest -v tests

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install SVMTK
       run:
-        python3 -m pip install -v . pytest
+        python3 -m pip install -v .[test]
 
     - name: Run Tests
-      run: pytest -v
+      run: pytest -v tests

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.so
 
 __pycache__
+tests/bin

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,10 +21,14 @@ requirements:
     - boost-cpp
     - cgal-cpp
     - eigen
+    - gmp
+    - mpfr
     - pybind11
     - python
     - pip
   run:
     - boost-cpp
     - eigen
+    - gmp
+    - mpfr
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,10 +27,9 @@ requirements:
     - python
     - pip
   run:
-    - boost-cpp
-    - eigen
     - gmp
     - mpfr
+    - numpy
     - python
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,3 +32,14 @@ requirements:
     - gmp
     - mpfr
     - python
+
+test:
+  requires:
+    - pytest
+  source_files:
+    - tests
+  imports:
+    - SVMTK
+
+  commands:
+    - pytest -v tests/Surface_test.py

--- a/python/src/SVMTK.cpp
+++ b/python/src/SVMTK.cpp
@@ -1,6 +1,11 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
+#include <pybind11/complex.h>
+#include <pybind11/chrono.h>
 
 #include "docstrings.h"
 #include "Surface.h"

--- a/setup.py
+++ b/setup.py
@@ -95,5 +95,11 @@ setup(
     ext_modules=[CMakeExtension("SVMTK")],
     cmdclass={'build_ext': CMakeBuild},
     test_suite='tests',
+    extras_require={
+        "test": [
+            "numpy",
+            "pytest",
+        ],
+    },
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -95,9 +95,11 @@ setup(
     ext_modules=[CMakeExtension("SVMTK")],
     cmdclass={'build_ext': CMakeBuild},
     test_suite='tests',
+    install_requires=[
+        "numpy",
+    ],
     extras_require={
         "test": [
-            "numpy",
             "pytest",
         ],
     },

--- a/tests/Slice_test.py
+++ b/tests/Slice_test.py
@@ -1,5 +1,9 @@
+import os
 import unittest
+
 import SVMTK
+
+tests_dir = os.path.dirname(__file__)
 
 
 class Slice_Test(unittest.TestCase):
@@ -21,10 +25,10 @@ class Slice_Test(unittest.TestCase):
         self.assertTrue( slice_.number_of_constraints() > 0)
         slice_.create_mesh(1.) 
         self.assertTrue( slice_.number_of_faces() > 0) 
-        slice_.save("tests/Data/slice.vtu")
-        slice_.save("tests/Data/slice.stl")
-        slice_.save("tests/Data/slice.off")
-        slice_.save("tests/Data/slice.mesh")
+        slice_.save(f"{tests_dir}/Data/slice.vtu")
+        slice_.save(f"{tests_dir}/Data/slice.stl")
+        slice_.save(f"{tests_dir}/Data/slice.off")
+        slice_.save(f"{tests_dir}/Data/slice.mesh")
 
     def test_slice_subdomains(self):
         slice_ = SVMTK.Slice(SVMTK.Plane_3(0,0,1,0))
@@ -75,8 +79,8 @@ class Slice_Test(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
     import os
-    os.remove("tests/Data/slice.vtu")
-    os.remove("tests/Data/slice.stl")
-    os.remove("tests/Data/slice.off")
-    os.remove("tests/Data/slice.mesh")
 
+    os.remove(f"{tests_dir}/Data/slice.vtu")
+    os.remove(f"{tests_dir}/Data/slice.stl")
+    os.remove(f"{tests_dir}/Data/slice.off")
+    os.remove(f"{tests_dir}/Data/slice.mesh")

--- a/tests/Surface_test.py
+++ b/tests/Surface_test.py
@@ -1,5 +1,12 @@
+import os
 import unittest
+
 import SVMTK
+import pytest
+
+tests_dir = os.path.dirname(__file__)
+
+
 def ellipsoid_function( x, y, z):
   return x*x + 4.*y*y +4.*z*z-1.;
 
@@ -11,11 +18,11 @@ class Surface_Test(unittest.TestCase):
     def test_surface_io(self):
         surface =SVMTK.Surface()  
         surface.make_cube(0.,0.,0.,1.,1.,1.,1) 
-        surface.save("tests/Data/cube.off")
-        surface.save("tests/Data/cube.stl")
-        surface= SVMTK.Surface("tests/Data/cube.off")
+        surface.save(f"{tests_dir}/Data/cube.off")
+        surface.save(f"{tests_dir}/Data/cube.stl")
+        surface= SVMTK.Surface(f"{tests_dir}/Data/cube.off")
         self.assertTrue(surface.num_vertices()==14 and surface.num_faces()==24 and surface.num_edges()==36) 
-        surface= SVMTK.Surface("tests/Data/cube.stl") 
+        surface= SVMTK.Surface(f"{tests_dir}/Data/cube.stl") 
         self.assertTrue(surface.num_vertices()==14 and surface.num_faces()==24 and surface.num_edges()==36)
 
     def test_surfaces_shapes(self):
@@ -74,14 +81,14 @@ class Surface_Test(unittest.TestCase):
         self.assertEqual(surface.span(2),(0.,3))
 
     def test_fill_holes(self):          
-        mech_shark = SVMTK.Surface("tests/Data/mech-holes-shark.off")
+        mech_shark = SVMTK.Surface(f"{tests_dir}/Data/mech-holes-shark.off")
         nb_holes = mech_shark.fill_holes()
         self.assertEqual(nb_holes,4)
         nb_holes = mech_shark.fill_holes()
         self.assertEqual(nb_holes,0)
 
     def test_triangulate_faces(self):
-        p = SVMTK.Surface("tests/Data/P.off")
+        p = SVMTK.Surface(f"{tests_dir}/Data/P.off")
         self.assertTrue(p.triangulate_faces())
 
     def test_surface_clip(self):
@@ -142,7 +149,7 @@ class Surface_Test(unittest.TestCase):
         self.assertTrue(surface.num_edges(),126) 
 
     def test_separate_narrow_gaps(self):
-         s1=SVMTK.Surface("tests/Data/narrow_gap.off")
+         s1=SVMTK.Surface(f"{tests_dir}/Data/narrow_gap.off")
          a = s1.separate_narrow_gaps(adjustment=-.1,smoothing=0.1)
          self.assertTrue(a[0]) 
          self.assertEqual(a[1],0) 
@@ -197,8 +204,6 @@ class Surface_Test(unittest.TestCase):
 
 if __name__ == '__main__':
     import os
-    unittest.main()        
+    unittest.main()
     os.remove('tests/Data/cube.stl')
     os.remove('tests/Data/cube.off')
-
-

--- a/tests/Surface_test.py
+++ b/tests/Surface_test.py
@@ -91,16 +91,18 @@ class Surface_Test(unittest.TestCase):
         p = SVMTK.Surface(f"{tests_dir}/Data/P.off")
         self.assertTrue(p.triangulate_faces())
 
+    @pytest.mark.xfail(strict=True)
     def test_surface_clip(self):
-        surface =SVMTK.Surface()   
-        surface.make_cube(-1.,-1.,-1.,1.,1.,1.,1) 
-        surface.clip(0,0,1.,0,True) 
+        surface =SVMTK.Surface()
+        surface.make_cube(-1.,-1.,-1.,1.,1.,1.,1)
+        surface.clip(0,0,1.,0,True)
         self.assertAlmostEqual(surface.span(0)[0],-1.0,8)
-        self.assertAlmostEqual(surface.span(0)[1],1.0,8)        
+        self.assertAlmostEqual(surface.span(0)[1],1.0,8)
         self.assertAlmostEqual(surface.span(1)[0],-1.0,8)
-        self.assertAlmostEqual(surface.span(1)[1],1.0,8)        
+        self.assertAlmostEqual(surface.span(1)[1],1.0,8)
         self.assertAlmostEqual(surface.span(2)[0],-1.,8)
-        self.assertAlmostEqual(surface.span(2)[1],0.0,8)        
+        # FIXME: this assertion is failing
+        self.assertAlmostEqual(surface.span(2)[1],0.0,8)
 
     def test_adjust_boundary(self):
         surface =SVMTK.Surface()   

--- a/tests/Utility_test.py
+++ b/tests/Utility_test.py
@@ -1,6 +1,9 @@
+import os
 import unittest
+
 import SVMTK
 
+tests_dir = os.path.dirname(__file__)
 
 class Utility_Test(unittest.TestCase):
 
@@ -86,8 +89,8 @@ class Utility_Test(unittest.TestCase):
 
 
     def test_union_partially_overlapping_surfaces(self): 
-        s1 =SVMTK.Surface("tests/Data/s1.off")
-        s2 =SVMTK.Surface("tests/Data/s2.off")       
+        s1 =SVMTK.Surface(f"{tests_dir}/Data/s1.off")
+        s2 =SVMTK.Surface(f"{tests_dir}/Data/s2.off")       
         s5  = SVMTK.union_partially_overlapping_surfaces(s1,s2,50,0.7,1,8)
         self.assertTrue(s5.num_faces()>0) 
 

--- a/tests/cpp_test.py
+++ b/tests/cpp_test.py
@@ -1,15 +1,21 @@
-import unittest
-import subprocess
 import os
+import subprocess
+import unittest
+
+import pytest
+
+SVMTK_test = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "bin", "SVMTK_test")
+)
+
 
 class MainTest(unittest.TestCase):
+    @pytest.mark.skipif(not os.path.exists(SVMTK_test), reason="C++ tests not built")
     def test_cpp(self):
         print("\n\nTesting C++ code...")
-        subprocess.check_call("./"+os.path.join(os.path.dirname(
-            os.path.relpath(__file__)), 'bin', 'SVMTK_test'),shell=True)
+        subprocess.check_call(SVMTK_test, shell=True)
         print()  # for prettier output
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
- add missing gmp, mpfr dependencies in conda recipe
- run Python tests on CI
- restore removed pybind includes, which broke Python
- mark test_surface_clip xfail, because it's currently failing
- remove CWD assumptions from python tests by resolving the tests directory