### PR TITLE
conda: pin cgal 5.4.1 (matches submodule)

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,8 +18,10 @@ requirements:
     - cmake
     - make
   host:
-    - boost-cpp
-    - cgal-cpp=5.3.1
+    # boost-cpp pin neede for cgal pin
+    - boost-cpp=1.74
+    # cgal 5.4.1 needed due to compatibility issue in clipping
+    - cgal-cpp=5.4.1
     - eigen
     - gmp
     - mpfr


### PR DESCRIPTION
and pin boost to match, overriding boost pin in conda-forge-pinning, which is incompatible with cgal 5.4.1